### PR TITLE
Fire and forget

### DIFF
--- a/source/Channel.cpp
+++ b/source/Channel.cpp
@@ -831,48 +831,6 @@ void Channel::BasicPublish(const std::string &exchange_name,
       StringToBytes(routing_key), mandatory, immediate, &properties,
       StringToBytes(message->Body())));
 
-  // If we've done things correctly we can get one of 4 things back from the
-  // broker
-  // - basic.ack - our channel is in confirm mode, messsage was 'dealt with' by
-  // the broker
-  // - basic.nack - our channel is in confirm mode, queue has max-length set and
-  // is full, queue overflow stratege is reject-publish
-  // - basic.return then basic.ack - the message wasn't delievered, but was
-  // dealt with
-  // - channel.close - probably tried to publish to a non-existant exchange, in
-  // any case error!
-  // - connection.clsoe - something really bad happened
-  const boost::array<boost::uint32_t, 3> PUBLISH_ACK = {
-      {AMQP_BASIC_ACK_METHOD, AMQP_BASIC_RETURN_METHOD,
-       AMQP_BASIC_NACK_METHOD}};
-  amqp_frame_t response;
-  boost::array<amqp_channel_t, 1> channels = {{channel}};
-  m_impl->GetMethodOnChannel(channels, response, PUBLISH_ACK);
-
-  if (AMQP_BASIC_NACK_METHOD == response.payload.method.id) {
-    amqp_basic_nack_t *return_method =
-        reinterpret_cast<amqp_basic_nack_t *>(response.payload.method.decoded);
-    MessageRejectedException message_rejected(return_method->delivery_tag);
-    m_impl->ReturnChannel(channel);
-    m_impl->MaybeReleaseBuffersOnChannel(channel);
-    throw message_rejected;
-  }
-
-  if (AMQP_BASIC_RETURN_METHOD == response.payload.method.id) {
-    MessageReturnedException message_returned =
-        m_impl->CreateMessageReturnedException(
-            *(reinterpret_cast<amqp_basic_return_t *>(
-                response.payload.method.decoded)),
-            channel);
-
-    const boost::array<boost::uint32_t, 1> BASIC_ACK = {
-        {AMQP_BASIC_ACK_METHOD}};
-    m_impl->GetMethodOnChannel(channels, response, BASIC_ACK);
-    m_impl->ReturnChannel(channel);
-    m_impl->MaybeReleaseBuffersOnChannel(channel);
-    throw message_returned;
-  }
-
   m_impl->ReturnChannel(channel);
   m_impl->MaybeReleaseBuffersOnChannel(channel);
 }

--- a/source/ChannelImpl.cpp
+++ b/source/ChannelImpl.cpp
@@ -185,12 +185,6 @@ amqp_channel_t Channel::ChannelImpl::CreateNewChannel() {
   DoRpcOnChannel<boost::array<boost::uint32_t, 1> >(
       new_channel, AMQP_CHANNEL_OPEN_METHOD, &channel_open, OPEN_OK);
 
-  static const boost::array<boost::uint32_t, 1> CONFIRM_OK = {
-      {AMQP_CONFIRM_SELECT_OK_METHOD}};
-  amqp_confirm_select_t confirm_select = {};
-  DoRpcOnChannel<boost::array<boost::uint32_t, 1> >(
-      new_channel, AMQP_CONFIRM_SELECT_METHOD, &confirm_select, CONFIRM_OK);
-
   m_channels.at(new_channel) = CS_Open;
 
   return new_channel;


### PR DESCRIPTION
This removes the channel publisher confirm mode, which means that we don't wait for a whole roundtrip on every publish. See https://github.com/twig-energy/EPEXcpp/issues/1975 and https://github.com/alanxz/SimpleAmqpClient/issues/25 for context.

The positive is that we'll send the messages as fast as possible. The downside is that we'll never get any errors, on for example unroutable messages or network issues. I've tested it locally and it seems to work. If we merge this we should be very confident that our application can handle silently loosing a lot of messages it's sending. 