### PR TITLE
Adds SIMPLEAMQPCLIENT_ENABLE_PUBLISH_CONFIRM compile flag

### DIFF
--- a/cmake/variables.cmake
+++ b/cmake/variables.cmake
@@ -41,7 +41,7 @@ if(NOT PROJECT_IS_TOP_LEVEL)
 endif()
 
 
-option(SIMPLEAMQPCLIENT_ENABLE_PUBLISH_CONFIRM "enable publisher confirms mode" ON)
+option(SIMPLEAMQPCLIENT_ENABLE_PUBLISH_CONFIRM "enable publisher confirms mode" OFF)
 if (${SIMPLEAMQPCLIENT_ENABLE_PUBLISH_CONFIRM})
   add_compile_definitions(SIMPLEAMQPCLIENT_ENABLE_PUBLISH_CONFIRM=1)
 endif ()

--- a/cmake/variables.cmake
+++ b/cmake/variables.cmake
@@ -39,3 +39,9 @@ if(NOT PROJECT_IS_TOP_LEVEL)
     set(warning_guard SYSTEM)
   endif()
 endif()
+
+
+option(SIMPLEAMQPCLIENT_ENABLE_PUBLISH_CONFIRM "enable publisher confirms mode" ON)
+if (${SIMPLEAMQPCLIENT_ENABLE_PUBLISH_CONFIRM})
+  add_compile_definitions(SIMPLEAMQPCLIENT_ENABLE_PUBLISH_CONFIRM=1)
+endif ()

--- a/source/Channel.cpp
+++ b/source/Channel.cpp
@@ -831,6 +831,7 @@ void Channel::BasicPublish(const std::string &exchange_name,
       StringToBytes(routing_key), mandatory, immediate, &properties,
       StringToBytes(message->Body())));
 
+#ifdef SIMPLEAMQPCLIENT_ENABLE_PUBLISH_CONFIRM
   // If we've done things correctly we can get one of 4 things back from the
   // broker
   // - basic.ack - our channel is in confirm mode, messsage was 'dealt with' by
@@ -872,7 +873,7 @@ void Channel::BasicPublish(const std::string &exchange_name,
     m_impl->MaybeReleaseBuffersOnChannel(channel);
     throw message_returned;
   }
-
+#endif
   m_impl->ReturnChannel(channel);
   m_impl->MaybeReleaseBuffersOnChannel(channel);
 }

--- a/source/ChannelImpl.cpp
+++ b/source/ChannelImpl.cpp
@@ -185,11 +185,13 @@ amqp_channel_t Channel::ChannelImpl::CreateNewChannel() {
   DoRpcOnChannel<boost::array<boost::uint32_t, 1> >(
       new_channel, AMQP_CHANNEL_OPEN_METHOD, &channel_open, OPEN_OK);
 
+#ifdef SIMPLEAMQPCLIENT_ENABLE_PUBLISH_CONFIRM
   static const boost::array<boost::uint32_t, 1> CONFIRM_OK = {
       {AMQP_CONFIRM_SELECT_OK_METHOD}};
   amqp_confirm_select_t confirm_select = {};
   DoRpcOnChannel<boost::array<boost::uint32_t, 1> >(
       new_channel, AMQP_CONFIRM_SELECT_METHOD, &confirm_select, CONFIRM_OK);
+#endif
 
   m_channels.at(new_channel) = CS_Open;
 


### PR DESCRIPTION
If enabled this turns (publisher confirms)[https://www.rabbitmq.com/confirms.html#publisher-confirms] on for the created channels.