### PR TITLE
Adds heartbeat timeouts and socket open timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      rabbitmq:
+        image: rabbitmq:3
+        ports:
+          - 5672:5672
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,6 @@ jobs:
 
     - name: Test
       working-directory: build
+      env:
+        AMQP_BROKER: "localhost"
       run: ctest --output-on-failure -C Release -j 2

--- a/include/SimpleAmqpClient/Channel.h
+++ b/include/SimpleAmqpClient/Channel.h
@@ -109,6 +109,8 @@ class SIMPLEAMQPCLIENT_EXPORT Channel : boost::noncopyable {
     int port;           ///< Port to connect to, default is 5672.
     int frame_max;      ///< Max frame size in bytes. Default 128KB.
     bool is_publisher_confirms = true; ///< Whether or not the channel is created in publisher confirms mode.
+    int socket_open_timeout_seconds = 0; //< 0 means never time out
+    int heartbeat_timeout_seconds = 0;  //< 0 means disable heartbeats
     /// One of BasicAuth or ExternalSaslAuth is required.
     boost::variant<BasicAuth, ExternalSaslAuth> auth;
     /// Connect using TLS/SSL when set, otherwise use an unencrypted channel.
@@ -921,20 +923,30 @@ class SIMPLEAMQPCLIENT_EXPORT Channel : boost::noncopyable {
   bool BasicConsumeMessage(Envelope::ptr_t &envelope, int timeout = -1);
 
  private:
-  static ChannelImpl *OpenChannel(const std::string &host, int port,
-                                  const std::string &username,
-                                  const std::string &password,
-                                  const std::string &vhost, int frame_max,
-                                  bool sasl_external, bool is_publisher_confirms);
+   static ChannelImpl* OpenChannel(const std::string& host,
+                                   int port,
+                                   const std::string& username,
+                                   const std::string& password,
+                                   const std::string& vhost,
+                                   int frame_max,
+                                   bool sasl_external,
+                                   bool is_publisher_confirms,
+                                   int socket_open_timeout_seconds,
+                                   int hearbeat_timeout_seconds);
 
-  static ChannelImpl *OpenSecureChannel(const std::string &host, int port,
-                                        const std::string &username,
-                                        const std::string &password,
-                                        const std::string &vhost, int frame_max,
-                                        const OpenOpts::TLSParams &tls_params,
-                                        bool sasl_external, bool is_publisher_confirms);
+   static ChannelImpl* OpenSecureChannel(const std::string& host,
+                                         int port,
+                                         const std::string& username,
+                                         const std::string& password,
+                                         const std::string& vhost,
+                                         int frame_max,
+                                         const OpenOpts::TLSParams& tls_params,
+                                         bool sasl_external,
+                                         bool is_publisher_confirms,
+                                         int socket_open_timeout_seconds,
+                                         int hearbeat_timeout_seconds);
 
-  /// PIMPL idiom
+   /// PIMPL idiom
   boost::scoped_ptr<ChannelImpl> m_impl;
 };
 

--- a/include/SimpleAmqpClient/Channel.h
+++ b/include/SimpleAmqpClient/Channel.h
@@ -109,7 +109,7 @@ class SIMPLEAMQPCLIENT_EXPORT Channel : boost::noncopyable {
     int port;           ///< Port to connect to, default is 5672.
     int frame_max;      ///< Max frame size in bytes. Default 128KB.
     bool is_publisher_confirms = true; ///< Whether or not the channel is created in publisher confirms mode.
-    int socket_open_timeout_seconds = 0; //< 0 means never time out
+    int socket_open_timeout_seconds = 0; //< less than or equal to 0 means never time out
     int heartbeat_timeout_seconds = 0;  //< 0 means disable heartbeats
     /// One of BasicAuth or ExternalSaslAuth is required.
     boost::variant<BasicAuth, ExternalSaslAuth> auth;
@@ -932,7 +932,7 @@ class SIMPLEAMQPCLIENT_EXPORT Channel : boost::noncopyable {
                                    bool sasl_external,
                                    bool is_publisher_confirms,
                                    int socket_open_timeout_seconds,
-                                   int hearbeat_timeout_seconds);
+                                   int heartbeat_timeout_seconds);
 
    static ChannelImpl* OpenSecureChannel(const std::string& host,
                                          int port,

--- a/include/SimpleAmqpClient/ChannelImpl.h
+++ b/include/SimpleAmqpClient/ChannelImpl.h
@@ -61,6 +61,7 @@ class Channel::ChannelImpl : boost::noncopyable {
 
   void DoLogin(const std::string &username, const std::string &password,
                const std::string &vhost, int frame_max,
+               int heartbeat_timeout_seconds,
                bool sasl_external = false);
   amqp_channel_t GetChannel();
   void ReturnChannel(amqp_channel_t channel);

--- a/source/Channel.cpp
+++ b/source/Channel.cpp
@@ -413,7 +413,7 @@ Channel::ChannelImpl* Channel::OpenChannel(const std::string& host,
                                            bool sasl_external,
                                            bool is_publisher_confirms,
                                            int socket_open_timeout_seconds,
-                                           int hearbeat_timeout_seconds)
+                                           int heartbeat_timeout_seconds)
 {
   ChannelImpl *impl = new ChannelImpl;
   impl->is_publisher_confirms = is_publisher_confirms;
@@ -435,7 +435,8 @@ Channel::ChannelImpl* Channel::OpenChannel(const std::string& host,
     }
     impl->CheckForError(sock);
 
-    impl->DoLogin(username, password, vhost, frame_max, hearbeat_timeout_seconds, sasl_external);
+    impl->DoLogin(username, password, vhost, frame_max,
+                  heartbeat_timeout_seconds, sasl_external);
   } catch (...) {
     amqp_destroy_connection(impl->m_connection);
     delete impl;

--- a/source/Channel.cpp
+++ b/source/Channel.cpp
@@ -202,15 +202,31 @@ Channel::ptr_t Channel::Open(const OpenOpts &opts) {
         const OpenOpts::BasicAuth &auth =
             boost::get<OpenOpts::BasicAuth>(opts.auth);
         return boost::make_shared<Channel>(
-            OpenChannel(opts.host, opts.port, auth.username, auth.password,
-                        opts.vhost, opts.frame_max, false, opts.is_publisher_confirms));
+            OpenChannel(opts.host,
+                        opts.port,
+                        auth.username,
+                        auth.password,
+                        opts.vhost,
+                        opts.frame_max,
+                        false,
+                        opts.is_publisher_confirms,
+                        opts.socket_open_timeout_seconds,
+                        opts.heartbeat_timeout_seconds));
       }
       case 1: {
-        const OpenOpts::ExternalSaslAuth &auth =
+        const OpenOpts::ExternalSaslAuth& auth =
             boost::get<OpenOpts::ExternalSaslAuth>(opts.auth);
         return boost::make_shared<Channel>(
-            OpenChannel(opts.host, opts.port, auth.identity, "", opts.vhost,
-                        opts.frame_max, true, opts.is_publisher_confirms));
+            OpenChannel(opts.host,
+                        opts.port,
+                        auth.identity,
+                        "",
+                        opts.vhost,
+                        opts.frame_max,
+                        true,
+                        opts.is_publisher_confirms,
+                        opts.socket_open_timeout_seconds,
+                        opts.heartbeat_timeout_seconds));
       }
       default:
         throw std::logic_error("Unhandled auth type");
@@ -220,16 +236,34 @@ Channel::ptr_t Channel::Open(const OpenOpts &opts) {
     case 0: {
       const OpenOpts::BasicAuth &auth =
           boost::get<OpenOpts::BasicAuth>(opts.auth);
-      return boost::make_shared<Channel>(OpenSecureChannel(
-          opts.host, opts.port, auth.username, auth.password, opts.vhost,
-          opts.frame_max, opts.tls_params.get(), false, opts.is_publisher_confirms));
+      return boost::make_shared<Channel>(
+          OpenSecureChannel(opts.host,
+                            opts.port,
+                            auth.username,
+                            auth.password,
+                            opts.vhost,
+                            opts.frame_max,
+                            opts.tls_params.get(),
+                            false,
+                            opts.is_publisher_confirms,
+                            opts.socket_open_timeout_seconds,
+                            opts.heartbeat_timeout_seconds));
     }
     case 1: {
       const OpenOpts::ExternalSaslAuth &auth =
           boost::get<OpenOpts::ExternalSaslAuth>(opts.auth);
       return boost::make_shared<Channel>(
-          OpenSecureChannel(opts.host, opts.port, auth.identity, "", opts.vhost,
-                            opts.frame_max, opts.tls_params.get(), true, opts.is_publisher_confirms));
+          OpenSecureChannel(opts.host,
+                            opts.port,
+                            auth.identity,
+                            "",
+                            opts.vhost,
+                            opts.frame_max,
+                            opts.tls_params.get(),
+                            true,
+                            opts.is_publisher_confirms,
+                            opts.socket_open_timeout_seconds,
+                            opts.heartbeat_timeout_seconds));
     }
     default:
       throw std::logic_error("Unhandled auth type");
@@ -370,12 +404,17 @@ Channel::ptr_t Channel::CreateSecureFromUri(
   return Open(opts);
 }
 
-Channel::ChannelImpl *Channel::OpenChannel(const std::string &host, int port,
-                                           const std::string &username,
-                                           const std::string &password,
-                                           const std::string &vhost,
-                                           int frame_max, bool sasl_external,
-                                           bool is_publisher_confirms) {
+Channel::ChannelImpl* Channel::OpenChannel(const std::string& host,
+                                           int port,
+                                           const std::string& username,
+                                           const std::string& password,
+                                           const std::string& vhost,
+                                           int frame_max,
+                                           bool sasl_external,
+                                           bool is_publisher_confirms,
+                                           int socket_open_timeout_seconds,
+                                           int hearbeat_timeout_seconds)
+{
   ChannelImpl *impl = new ChannelImpl;
   impl->is_publisher_confirms = is_publisher_confirms;
   impl->m_connection = amqp_new_connection();
@@ -386,7 +425,14 @@ Channel::ChannelImpl *Channel::OpenChannel(const std::string &host, int port,
 
   try {
     amqp_socket_t *socket = amqp_tcp_socket_new(impl->m_connection);
-    int sock = amqp_socket_open(socket, host.c_str(), port);
+
+    int sock;
+    if (socket_open_timeout_seconds <= 0) {
+      sock = amqp_socket_open(socket, host.c_str(), port);
+    } else {
+      const timeval sock_timeout = timeval {socket_open_timeout_seconds, 0};
+      sock = amqp_socket_open_noblock(socket, host.c_str(), port, &sock_timeout);
+    }
     impl->CheckForError(sock);
 
     impl->DoLogin(username, password, vhost, frame_max, sasl_external);
@@ -401,12 +447,20 @@ Channel::ChannelImpl *Channel::OpenChannel(const std::string &host, int port,
 }
 
 #ifdef SAC_SSL_SUPPORT_ENABLED
-Channel::ChannelImpl *Channel::OpenSecureChannel(
-    const std::string &host, int port, const std::string &username,
-    const std::string &password, const std::string &vhost, int frame_max,
-    const OpenOpts::TLSParams &tls_params, bool sasl_external,
-    bool is_publisher_confirms) {
-  Channel::ChannelImpl *impl = new ChannelImpl;
+Channel::ChannelImpl* Channel::OpenSecureChannel(
+    const std::string& host,
+    int port,
+    const std::string& username,
+    const std::string& password,
+    const std::string& vhost,
+    int frame_max,
+    const OpenOpts::TLSParams& tls_params,
+    bool sasl_external,
+    bool is_publisher_confirms,
+    int socket_open_timeout_seconds,
+    int hearbeat_timeout_seconds)
+{
+  Channel::ChannelImpl* impl = new ChannelImpl;
   impl->is_publisher_confirms = is_publisher_confirms;
   impl->m_connection = amqp_new_connection();
   if (NULL == impl->m_connection) {
@@ -442,7 +496,13 @@ Channel::ChannelImpl *Channel::OpenSecureChannel(
       }
     }
 
-    status = amqp_socket_open(socket, host.c_str(), port);
+    if (socket_open_timeout_seconds <= 0) {
+      status = amqp_socket_open(socket, host.c_str(), port);
+    } else {
+      const timeval sock_timeout = timeval {socket_open_timeout_seconds, 0};
+      status = amqp_socket_open_noblock(socket, host.c_str(), port, &sock_timeout);
+    }
+
     if (status) {
       throw AmqpLibraryException::CreateException(
           status, "Error setting client certificate for socket");

--- a/source/Channel.cpp
+++ b/source/Channel.cpp
@@ -435,7 +435,7 @@ Channel::ChannelImpl* Channel::OpenChannel(const std::string& host,
     }
     impl->CheckForError(sock);
 
-    impl->DoLogin(username, password, vhost, frame_max, sasl_external);
+    impl->DoLogin(username, password, vhost, frame_max, hearbeat_timeout_seconds, sasl_external);
   } catch (...) {
     amqp_destroy_connection(impl->m_connection);
     delete impl;
@@ -508,7 +508,7 @@ Channel::ChannelImpl* Channel::OpenSecureChannel(
           status, "Error setting client certificate for socket");
     }
 
-    impl->DoLogin(username, password, vhost, frame_max, sasl_external);
+    impl->DoLogin(username, password, vhost, frame_max, hearbeat_timeout_seconds, sasl_external);
   } catch (...) {
     amqp_destroy_connection(impl->m_connection);
     delete impl;

--- a/source/ChannelImpl.cpp
+++ b/source/ChannelImpl.cpp
@@ -54,8 +54,6 @@
 #include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>
 
-#define BROKER_HEARTBEAT 0
-
 namespace AmqpClient {
 
 namespace {
@@ -122,6 +120,7 @@ Channel::ChannelImpl::~ChannelImpl() {}
 void Channel::ChannelImpl::DoLogin(const std::string &username,
                                    const std::string &password,
                                    const std::string &vhost, int frame_max,
+                                   int heartbeat_timeout_seconds,
                                    bool sasl_external) {
   amqp_table_entry_t capabilties[1];
   amqp_table_entry_t capability_entry;
@@ -143,12 +142,12 @@ void Channel::ChannelImpl::DoLogin(const std::string &username,
   if (sasl_external) {
     CheckRpcReply(0, amqp_login_with_properties(
                          m_connection, vhost.c_str(), 0, frame_max,
-                         BROKER_HEARTBEAT, &client_properties,
+                         heartbeat_timeout_seconds, &client_properties,
                          AMQP_SASL_METHOD_EXTERNAL, username.c_str()));
   } else {
     CheckRpcReply(
         0, amqp_login_with_properties(m_connection, vhost.c_str(), 0, frame_max,
-                                      BROKER_HEARTBEAT, &client_properties,
+                                      heartbeat_timeout_seconds, &client_properties,
                                       AMQP_SASL_METHOD_PLAIN, username.c_str(),
                                       password.c_str()));
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,4 +32,5 @@ target_link_libraries(
 )
 target_compile_features(SimpleAmqpClient_test PRIVATE cxx_std_17)
 
+add_test(NAME simple_amqp_client_test COMMAND SimpleAmqpClient_test "--gtest_color=yes" "--gtest_output=xml:")
 add_folders(Test)


### PR DESCRIPTION
Since, without these the library might hang indefinitely when doing low level operations if the connection is broken.

For background see
- https://www.rabbitmq.com/heartbeats.html
- https://github.com/alanxz/SimpleAmqpClient/issues/20
- https://github.com/alanxz/rabbitmq-c/issues/380
