### PR TITLE
Update install-config.cmake.in

### DIFF
--- a/cmake/install-config.cmake.in
+++ b/cmake/install-config.cmake.in
@@ -2,6 +2,7 @@ include(CMakeFindDependencyMacro)
 
 if(NOT "@BUILD_SHARED_LIBS@")
   find_dependency(fmt)
+  find_dependency(rabbitmq-c)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/SimpleAmqpClientTargets.cmake")


### PR DESCRIPTION
### Why 
Because otherwise the users of our library will have to write find_package(rabbitmq... themselves

### What was changed
Making sure that when installing we find the dependencies we need

### On Call