### PR TITLE
Keep up to date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   BUILD_TYPE: Release
-  VCPKG_COMMIT: "898b728edc5e0d12b50015f9cd18247c4257a3eb"
+  VCPKG_COMMIT: "943c5ef1c8f6b5e6ced092b242c8299caae2ff01"
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   BUILD_TYPE: Release
-  VCPKG_BINARY_SOURCES: 'default;nuget,GitHub,read'
+  VCPKG_COMMIT: "898b728edc5e0d12b50015f9cd18247c4257a3eb"
 
 jobs:
   build:
@@ -21,22 +21,23 @@ jobs:
         ports:
           - 5672:5672
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install static analyzers
       run: sudo apt-get install clang-tidy cppcheck -y -q
 
-    - name: vcpkg
-      shell: 'bash'
-      run: |
-        git clone https://github.com/Microsoft/vcpkg.git && ./vcpkg/bootstrap-vcpkg.sh
-        mono `./vcpkg/vcpkg fetch nuget | tail -n 1` sources add -source "https://nuget.pkg.github.com/twig-energy/index.json" -storepasswordincleartext -name "GitHub" -username "twig-energy" -password "${{ secrets.GITHUB_TOKEN }}"
+
+    - name: Install vcpkg
+      uses: friendlyanon/setup-vcpkg@v1
+      with:
+        committish: "${{ env.VCPKG_COMMIT }}"
+        cache-version: "ci-ubuntu"
+        cache-restore-keys: |
+          vcpkg-Linux-ci-ubuntu-
 
     - name: Configure
-      shell: 'bash'
-      env:
-        VCPKG_ROOT: "./vcpkg"
-      run: cmake --preset=ci-ubuntu
+      run: |
+        cmake --preset=ci-ubuntu
 
     - name: Build
       run: cmake --build --preset=ci-ubuntu -j 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": false, // we want as few conflicts as possible
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,9 +73,6 @@ target_include_directories(
 target_compile_definitions(SimpleAmqpClient_SimpleAmqpClient
                            PUBLIC SAC_SSL_SUPPORT_ENABLED)
 
-target_compile_definitions(SimpleAmqpClient_SimpleAmqpClient
-                           PUBLIC SAC_SSL_SUPPORT_ENABLED)
-
 target_compile_features(SimpleAmqpClient_SimpleAmqpClient PUBLIC cxx_std_17)
 
 target_link_libraries(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ find_package(Boost REQUIRED chrono system)
 find_path(BOOST_VARIANT_INCLUDE_DIRS "boost/variant.hpp")
 find_path(BOOST_ALGORITHM_INCLUDE_DIRS "boost/algorithm")
 find_path(BOOST_FOREACH_INCLUDE_DIRS "boost/foreach.hpp")
-find_path(RABBITMQC_INCLUDE_DIRS "amqp.h")
 
 # ---- Declare library ----
 
@@ -63,18 +62,13 @@ set_target_properties(
 
 target_include_directories(
   SimpleAmqpClient_SimpleAmqpClient ${warning_guard}
-  PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
-         "$<BUILD_INTERFACE:${BOOST_VARIANT_INCLUDE_DIRS}>"
-         "$<BUILD_INTERFACE:${BOOST_ALGORITHM_INCLUDE_DIRS}>"
-         "$<BUILD_INTERFACE:${BOOST_FOREACH_INCLUDE_DIRS}>"
-         "$<BUILD_INTERFACE:${RABBITMQC_INCLUDE_DIRS}>")
+  PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
 
 target_include_directories(
-  SimpleAmqpClient_SimpleAmqpClient ${warning_guard} SYSTEM
+  SimpleAmqpClient_SimpleAmqpClient SYSTEM
   PUBLIC "$<BUILD_INTERFACE:${BOOST_VARIANT_INCLUDE_DIRS}>"
          "$<BUILD_INTERFACE:${BOOST_ALGORITHM_INCLUDE_DIRS}>"
-         "$<BUILD_INTERFACE:${BOOST_FOREACH_INCLUDE_DIRS}>"
-         "$<BUILD_INTERFACE:${RABBITMQC_INCLUDE_DIRS}>")
+         "$<BUILD_INTERFACE:${BOOST_FOREACH_INCLUDE_DIRS}>")
 
 target_compile_definitions(SimpleAmqpClient_SimpleAmqpClient
                            PUBLIC SAC_SSL_SUPPORT_ENABLED)

--- a/cmake/install-config.cmake.in
+++ b/cmake/install-config.cmake.in
@@ -2,6 +2,7 @@ include(CMakeFindDependencyMacro)
 
 if(NOT "@BUILD_SHARED_LIBS@")
   find_dependency(fmt)
+  find_dependency(Boost)
   find_dependency(rabbitmq-c)
 endif()
 

--- a/include/SimpleAmqpClient/Bytes.h
+++ b/include/SimpleAmqpClient/Bytes.h
@@ -1,7 +1,7 @@
 #ifndef SIMPLEAMQPCLIENT_BYTES_H
 #define SIMPLEAMQPCLIENT_BYTES_H
 
-#include <amqp.h>
+#include <rabbitmq-c/amqp.h>
 #include <boost/utility/string_ref.hpp>
 
 #include <string>

--- a/include/SimpleAmqpClient/ChannelImpl.h
+++ b/include/SimpleAmqpClient/ChannelImpl.h
@@ -29,8 +29,8 @@
  */
 
 // Put these first to avoid warnings about INT#_C macro redefinition
-#include <amqp.h>
-#include <amqp_framing.h>
+#include <rabbitmq-c/amqp.h>
+#include <rabbitmq-c/framing.h>
 
 #include <boost/array.hpp>
 

--- a/include/SimpleAmqpClient/TableImpl.h
+++ b/include/SimpleAmqpClient/TableImpl.h
@@ -28,7 +28,7 @@
  * ***** END LICENSE BLOCK *****
  */
 
-#include <amqp.h>
+#include <rabbitmq-c/amqp.h>
 
 #include <boost/cstdint.hpp>
 #include <boost/shared_ptr.hpp>

--- a/source/AmqpException.cpp
+++ b/source/AmqpException.cpp
@@ -28,8 +28,8 @@
 
 #include "SimpleAmqpClient/AmqpException.h"
 
-#include <amqp.h>
-#include <amqp_framing.h>
+#include <rabbitmq-c/amqp.h>
+#include <rabbitmq-c/framing.h>
 #include <assert.h>
 
 #include <boost/lexical_cast.hpp>

--- a/source/AmqpLibraryException.cpp
+++ b/source/AmqpLibraryException.cpp
@@ -29,7 +29,7 @@
 // Put these first to avoid warnings about INT#_C macro redefinition
 #include "SimpleAmqpClient/AmqpLibraryException.h"
 
-#include <amqp.h>
+#include <rabbitmq-c/amqp.h>
 #include <stdlib.h>
 
 namespace AmqpClient {

--- a/source/AmqpResponseLibraryException.cpp
+++ b/source/AmqpResponseLibraryException.cpp
@@ -29,7 +29,7 @@
 // Put these first to avoid warnings about INT#_C macro redefinition
 #include "SimpleAmqpClient/AmqpResponseLibraryException.h"
 
-#include <amqp.h>
+#include <rabbitmq-c/amqp.h>
 #include <stdlib.h>
 
 namespace AmqpClient {

--- a/source/BasicMessage.cpp
+++ b/source/BasicMessage.cpp
@@ -29,8 +29,8 @@
 // Put these first to avoid warnings about INT#_C macro redefinition
 #include "SimpleAmqpClient/BasicMessage.h"
 
-#include <amqp.h>
-#include <amqp_framing.h>
+#include <rabbitmq-c/amqp.h>
+#include <rabbitmq-c/framing.h>
 
 #include <boost/optional/optional.hpp>
 #include <cstring>

--- a/source/Channel.cpp
+++ b/source/Channel.cpp
@@ -27,11 +27,11 @@
  */
 
 // Put these first to avoid warnings about INT#_C macro redefinition
-#include <amqp.h>
-#include <amqp_framing.h>
-#include <amqp_tcp_socket.h>
+#include <rabbitmq-c/amqp.h>
+#include <rabbitmq-c/framing.h>
+#include <rabbitmq-c/tcp_socket.h>
 #ifdef SAC_SSL_SUPPORT_ENABLED
-#include <amqp_ssl_socket.h>
+#include <rabbitmq-c/ssl_socket.h>
 #endif
 
 #include <string.h>

--- a/source/TableImpl.cpp
+++ b/source/TableImpl.cpp
@@ -32,7 +32,7 @@
 
 #include "SimpleAmqpClient/TableImpl.h"
 
-#include <amqp.h>
+#include <rabbitmq-c/amqp.h>
 #include <string.h>
 
 #include <algorithm>

--- a/test/source/test_message.cpp
+++ b/test/source/test_message.cpp
@@ -26,7 +26,7 @@
  * ***** END LICENSE BLOCK *****
  */
 
-#include <amqp.h>
+#include <rabbitmq-c/amqp.h>
 
 #include <algorithm>
 #include <boost/array.hpp>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -19,5 +19,5 @@
       ]
     }
   },
-  "builtin-baseline": "898b728edc5e0d12b50015f9cd18247c4257a3eb"
+  "builtin-baseline": "943c5ef1c8f6b5e6ced092b242c8299caae2ff01"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -19,5 +19,5 @@
       ]
     }
   },
-  "builtin-baseline": "a3df696929b28195b0d7a477ba6cd16dba48fa52"
+  "builtin-baseline": "898b728edc5e0d12b50015f9cd18247c4257a3eb"
 }


### PR DESCRIPTION
### Why 
new vcpkg has deprecated how rabbitmq is consumed. This will bite us wif we do not handle it proactively

### What was changed
- bumped vcpkg
- mordernized ci and vcpkg
