### PR TITLE
CMake: Fix boost dependencies when consuming.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   BUILD_TYPE: Release
-  VCPKG_COMMIT: "943c5ef1c8f6b5e6ced092b242c8299caae2ff01"
+  VCPKG_COMMIT: "d5ec528843d29e3a52d745a64b469f810b2cedbf"
 
 jobs:
   build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.28)
 
 include(cmake/prelude.cmake)
 
 project(
   SimpleAmqpClient
-  VERSION 2.5.1
+  VERSION 2.5.2
   DESCRIPTION "Short description"
   HOMEPAGE_URL "https://github.com/twig-energy/SimpleAmqpClient"
   LANGUAGES CXX)
@@ -13,10 +13,7 @@ include(cmake/project-is-top-level.cmake)
 include(cmake/variables.cmake)
 
 find_package(rabbitmq-c CONFIG REQUIRED)
-find_package(Boost REQUIRED chrono system)
-find_path(BOOST_VARIANT_INCLUDE_DIRS "boost/variant.hpp")
-find_path(BOOST_ALGORITHM_INCLUDE_DIRS "boost/algorithm")
-find_path(BOOST_FOREACH_INCLUDE_DIRS "boost/foreach.hpp")
+find_package(Boost REQUIRED COMPONENTS algorithm chrono foreach lexical_cast system variant)
 
 # ---- Declare library ----
 
@@ -64,12 +61,6 @@ target_include_directories(
   SimpleAmqpClient_SimpleAmqpClient ${warning_guard}
   PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
 
-target_include_directories(
-  SimpleAmqpClient_SimpleAmqpClient SYSTEM
-  PUBLIC "$<BUILD_INTERFACE:${BOOST_VARIANT_INCLUDE_DIRS}>"
-         "$<BUILD_INTERFACE:${BOOST_ALGORITHM_INCLUDE_DIRS}>"
-         "$<BUILD_INTERFACE:${BOOST_FOREACH_INCLUDE_DIRS}>")
-
 target_compile_definitions(SimpleAmqpClient_SimpleAmqpClient
                            PUBLIC SAC_SSL_SUPPORT_ENABLED)
 
@@ -77,7 +68,7 @@ target_compile_features(SimpleAmqpClient_SimpleAmqpClient PUBLIC cxx_std_17)
 
 target_link_libraries(
   SimpleAmqpClient_SimpleAmqpClient
-  PUBLIC rabbitmq::rabbitmq-static Boost::boost Boost::chrono Boost::system)
+  PUBLIC rabbitmq::rabbitmq-static Boost::algorithm Boost::boost Boost::chrono Boost::foreach Boost::lexical_cast Boost::system Boost::variant)
 
 # ---- Install rules ----
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ include(cmake/prelude.cmake)
 
 project(
   SimpleAmqpClient
-  VERSION 2.5.2
+  VERSION 2.5.1
   DESCRIPTION "Short description"
   HOMEPAGE_URL "https://github.com/twig-energy/SimpleAmqpClient"
   LANGUAGES CXX)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,7 +2,7 @@
   "version": 2,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 14,
+    "minor": 28,
     "patch": 0
   },
   "configurePresets": [

--- a/cmake/install-config.cmake.in
+++ b/cmake/install-config.cmake.in
@@ -1,8 +1,7 @@
 include(CMakeFindDependencyMacro)
 
 if(NOT "@BUILD_SHARED_LIBS@")
-  find_dependency(fmt)
-  find_dependency(Boost)
+  find_dependency(Boost COMPONENTS algorithm chrono foreach lexical-cast system variant)
   find_dependency(rabbitmq-c)
 endif()
 

--- a/cmake/install-config.cmake.in
+++ b/cmake/install-config.cmake.in
@@ -1,7 +1,7 @@
 include(CMakeFindDependencyMacro)
 
 if(NOT "@BUILD_SHARED_LIBS@")
-  find_dependency(Boost COMPONENTS algorithm chrono foreach lexical-cast system variant)
+  find_dependency(Boost COMPONENTS algorithm chrono foreach lexical_cast system variant)
   find_dependency(rabbitmq-c)
 endif()
 

--- a/include/SimpleAmqpClient/BasicMessage.h
+++ b/include/SimpleAmqpClient/BasicMessage.h
@@ -34,6 +34,7 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/utility.hpp>
 #include <string>
+#include <utility>
 
 #include "SimpleAmqpClient/Table.h"
 #include "SimpleAmqpClient/Util.h"
@@ -74,14 +75,14 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
    * @param body the message body.
    * @returns a new BasicMessage object
    */
-  static ptr_t Create(const std::string& body) {
-    return boost::make_shared<BasicMessage>(body);
+  static ptr_t Create(std::string body) {
+    return boost::make_shared<BasicMessage>(std::move(body));
   }
 
   /// Construct empty BasicMessage
   BasicMessage();
   /// Construct BasicMessage with given body
-  BasicMessage(const std::string& body);
+  BasicMessage(std::string body);
 
  public:
   /**
@@ -98,7 +99,7 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Sets the message body as a std::string
    */
-  void Body(const std::string& body);
+  void Body(std::string body);
 
   /**
    * Gets the content type property
@@ -107,7 +108,7 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Sets the content type property
    */
-  void ContentType(const std::string& content_type);
+  void ContentType(std::string content_type);
   /**
    * Determines whether the content type property is set
    */
@@ -124,7 +125,7 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Sets the content encoding property
    */
-  void ContentEncoding(const std::string& content_encoding);
+  void ContentEncoding(std::string content_encoding);
   /**
    * Determines whether the content encoding property is set
    */
@@ -175,7 +176,7 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Sets the correlation id property
    */
-  void CorrelationId(const std::string& correlation_id);
+  void CorrelationId(std::string correlation_id);
   /**
    * Determines whether the correlation id property is set
    */
@@ -192,7 +193,7 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Sets the reply to property
    */
-  void ReplyTo(const std::string& reply_to);
+  void ReplyTo(std::string reply_to);
   /**
    * Determines whether the reply to property is set
    */
@@ -209,7 +210,7 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Sets the expiration property
    */
-  void Expiration(const std::string& expiration);
+  void Expiration(std::string expiration);
   /**
    * Determines whether the expiration property is set
    */
@@ -226,7 +227,7 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Sets the message id property
    */
-  void MessageId(const std::string& message_id);
+  void MessageId(std::string message_id);
   /**
    * Determines if the message id property is set
    */
@@ -260,7 +261,7 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Sets the type property
    */
-  void Type(const std::string& type);
+  void Type(std::string type);
   /**
    * Determines whether the type property is set
    */
@@ -277,7 +278,7 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Sets the user id property
    */
-  void UserId(const std::string& user_id);
+  void UserId(std::string user_id);
   /**
    * Determines whether the user id property is set
    */
@@ -294,7 +295,7 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Sets the app id property
    */
-  void AppId(const std::string& app_id);
+  void AppId(std::string app_id);
   /**
    * Determines whether the app id property is set
    */
@@ -311,7 +312,7 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Sets the custer id property
    */
-  void ClusterId(const std::string& cluster_id);
+  void ClusterId(std::string cluster_id);
   /**
    * Determines if the cluster id property is set
    */

--- a/source/BasicMessage.cpp
+++ b/source/BasicMessage.cpp
@@ -35,6 +35,7 @@
 #include <boost/optional/optional.hpp>
 #include <cstring>
 #include <string>
+#include <utility>
 
 #include "SimpleAmqpClient/TableImpl.h"
 
@@ -60,8 +61,8 @@ struct BasicMessage::Impl {
 
 BasicMessage::BasicMessage() : m_impl(new Impl) {}
 
-BasicMessage::BasicMessage(const std::string& body) : m_impl(new Impl) {
-  Body(body);
+BasicMessage::BasicMessage(std::string body) : m_impl(new Impl) {
+  Body(std::move(body));
 }
 
 BasicMessage::~BasicMessage() {}
@@ -70,7 +71,7 @@ const std::string& BasicMessage::Body() const { return m_impl->body; }
 
 std::string& BasicMessage::Body() { return m_impl->body; }
 
-void BasicMessage::Body(const std::string& body) { m_impl->body = body; }
+void BasicMessage::Body(std::string body) { m_impl->body = std::move(body); }
 
 const std::string& BasicMessage::ContentType() const {
   if (ContentTypeIsSet()) {
@@ -80,8 +81,8 @@ const std::string& BasicMessage::ContentType() const {
   return empty;
 }
 
-void BasicMessage::ContentType(const std::string& content_type) {
-  m_impl->content_type = content_type;
+void BasicMessage::ContentType(std::string content_type) {
+  m_impl->content_type = std::move(content_type);
 }
 
 bool BasicMessage::ContentTypeIsSet() const {
@@ -98,8 +99,8 @@ const std::string& BasicMessage::ContentEncoding() const {
   return empty;
 }
 
-void BasicMessage::ContentEncoding(const std::string& content_encoding) {
-  m_impl->content_encoding = content_encoding;
+void BasicMessage::ContentEncoding(std::string content_encoding) {
+  m_impl->content_encoding = std::move(content_encoding);
 }
 
 bool BasicMessage::ContentEncodingIsSet() const {
@@ -144,8 +145,8 @@ const std::string& BasicMessage::CorrelationId() const {
   return empty;
 }
 
-void BasicMessage::CorrelationId(const std::string& correlation_id) {
-  m_impl->correlation_id = correlation_id;
+void BasicMessage::CorrelationId(std::string correlation_id) {
+  m_impl->correlation_id = std::move(correlation_id);
 }
 
 bool BasicMessage::CorrelationIdIsSet() const {
@@ -162,8 +163,8 @@ const std::string& BasicMessage::ReplyTo() const {
   return empty;
 }
 
-void BasicMessage::ReplyTo(const std::string& reply_to) {
-  m_impl->reply_to = reply_to;
+void BasicMessage::ReplyTo(std::string reply_to) {
+  m_impl->reply_to = std::move(reply_to);
 }
 
 bool BasicMessage::ReplyToIsSet() const {
@@ -180,8 +181,8 @@ const std::string& BasicMessage::Expiration() const {
   return empty;
 }
 
-void BasicMessage::Expiration(const std::string& expiration) {
-  m_impl->expiration = expiration;
+void BasicMessage::Expiration(std::string expiration) {
+  m_impl->expiration = std::move(expiration);
 }
 
 bool BasicMessage::ExpirationIsSet() const {
@@ -198,8 +199,8 @@ const std::string& BasicMessage::MessageId() const {
   return empty;
 }
 
-void BasicMessage::MessageId(const std::string& message_id) {
-  m_impl->message_id = message_id;
+void BasicMessage::MessageId(std::string message_id) {
+  m_impl->message_id = std::move(message_id);
 }
 
 bool BasicMessage::MessageIdIsSet() const {
@@ -229,7 +230,7 @@ const std::string& BasicMessage::Type() const {
   return empty;
 }
 
-void BasicMessage::Type(const std::string& type) { m_impl->type = type; }
+void BasicMessage::Type(std::string type) { m_impl->type = std::move(type); }
 
 bool BasicMessage::TypeIsSet() const { return m_impl->type.is_initialized(); }
 
@@ -243,8 +244,8 @@ const std::string& BasicMessage::UserId() const {
   return empty;
 }
 
-void BasicMessage::UserId(const std::string& user_id) {
-  m_impl->user_id = user_id;
+void BasicMessage::UserId(std::string user_id) {
+  m_impl->user_id = std::move(user_id);
 }
 
 bool BasicMessage::UserIdIsSet() const {
@@ -261,7 +262,7 @@ const std::string& BasicMessage::AppId() const {
   return empty;
 }
 
-void BasicMessage::AppId(const std::string& app_id) { m_impl->app_id = app_id; }
+void BasicMessage::AppId(std::string app_id) { m_impl->app_id = std::move(app_id); }
 
 bool BasicMessage::AppIdIsSet() const {
   return m_impl->app_id.is_initialized();
@@ -277,8 +278,8 @@ const std::string& BasicMessage::ClusterId() const {
   return empty;
 }
 
-void BasicMessage::ClusterId(const std::string& cluster_id) {
-  m_impl->cluster_id = cluster_id;
+void BasicMessage::ClusterId(std::string cluster_id) {
+  m_impl->cluster_id = std::move(cluster_id);
 }
 
 bool BasicMessage::ClusterIdIsSet() const {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.28)
 
 project(SimpleAmqpClientTests LANGUAGES CXX)
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simpleamqpclient",
-  "version-semver": "2.5.2",
+  "version-semver": "2.5.1",
   "dependencies": [
     "librabbitmq",
     "boost-chrono",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simpleamqpclient",
-  "version-semver": "2.5.1",
+  "version-semver": "2.5.2",
   "dependencies": [
     "librabbitmq",
     "boost-chrono",
@@ -19,5 +19,5 @@
       ]
     }
   },
-  "builtin-baseline": "943c5ef1c8f6b5e6ced092b242c8299caae2ff01"
+  "builtin-baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf"
 }


### PR DESCRIPTION
### Why 
CMake: When importing the library, you would manually have to download and link the different boost libraries used here. 

```
[cmake] CMake Error at build/vcpkg_installed/x64-linux-release/share/SimpleAmqpClient/SimpleAmqpClientTargets.cmake:60 (set_target_properties):
[cmake]   The link interface of target "SimpleAmqpClient::SimpleAmqpClient" contains:
[cmake] 
[cmake]     Boost::chrono
[cmake] 
[cmake]   but the target was not found.  Possible reasons include:
[cmake] 
[cmake]     * There is a typo in the target name.
[cmake]     * A find_package call is missing for an IMPORTED target.
[cmake]     * An ALIAS target is missing.
```

I suspect that is because the install-config.cmake file did not include the components.
Updating the vcpkg baseline also allow us to consume the header-only components of boosts in the same way as other libraries.

Furthermore, we can save a string copy per field in BasicMessage by accepting by-value and moving in. Will require change on the outside to get the effect of it though.

### What was changed
* Updated vcpkg baseline.
* Updated required CMake version.
* Added Boost components to install-config.cmake.
* Updated the way we include/link the boost components (due to new vcpkg baseline).
* Changed some `const std::string&` parameters to `std::string` with `std::move`.